### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
+## [2.0.1]
+
 - Support `on_ignored_nl` event in Ruby 2.6
+- Changed the repository owner from alpaca-tc to kufu
 
 ## [2.0.0]
 

--- a/lib/textlint/version.rb
+++ b/lib/textlint/version.rb
@@ -4,7 +4,7 @@ module Textlint
   module VERSION
     MAJOR = 2
     MINOR = 0
-    TINY  = 0
+    TINY  = 1
 
     STRING = [MAJOR, MINOR, TINY].compact.join('.')
   end


### PR DESCRIPTION
- Support `on_ignored_nl` event in Ruby 2.6 https://github.com/kufu/textlint-ruby/pull/1
- Changed the repository owner from alpaca-tc to kufu