### PR TITLE
Fix plugin name and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # textlint-ruby
 
-Ruby AST parser for [textlint-ruby-plugin](https://github.com/kufu/textlint-ruby-plugin).
+Ruby AST parser for [textlint-plugin-ruby](https://github.com/kufu/textlint-plugin-ruby).
 
 ## Installation
 


### PR DESCRIPTION
I found and then fixed a broken link of `text-plugin-ruby` and also fixed its name.